### PR TITLE
Feature/ot131 categories put endpoint

### DIFF
--- a/src/main/java/com/alkemy/ong/OngApplication.java
+++ b/src/main/java/com/alkemy/ong/OngApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -13,6 +14,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @EntityScan(basePackages = {"com.alkemy.ong.model"})
 @ComponentScan(basePackages = {"com.*"})
 @EnableJpaRepositories(basePackages = {"com.alkemy.ong.repository"})
+@EnableJpaAuditing
 @EnableTransactionManagement
 @EnableWebMvc
 @RepositoryRestController

--- a/src/main/java/com/alkemy/ong/controller/CategoriesController.java
+++ b/src/main/java/com/alkemy/ong/controller/CategoriesController.java
@@ -18,16 +18,9 @@ public class CategoriesController {
     @Autowired
     private CategoriesService categoriesService;
 
-    @PostMapping
-    public ResponseEntity<CategoriesDTO> create(@Valid @RequestBody CategoriesDTO dto) {
-        CategoriesDTO result = categoriesService.save(dto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(result);
-    }
-
     @PutMapping("/{id}")
     public ResponseEntity<CategoriesDTO> update(@PathVariable Long id, @Valid @RequestBody CategoriesDTO dto) {
         CategoriesDTO result = categoriesService.update(id, dto);
         return ResponseEntity.ok().body(result);
     }
-
 }

--- a/src/main/java/com/alkemy/ong/controller/CategoriesController.java
+++ b/src/main/java/com/alkemy/ong/controller/CategoriesController.java
@@ -1,0 +1,33 @@
+package com.alkemy.ong.controller;
+
+import com.alkemy.ong.dto.CategoriesDTO;
+import com.alkemy.ong.service.CategoriesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static com.alkemy.ong.util.Constants.REQ_MAPP_CATEGORIES;
+
+@RestController
+@RequestMapping(REQ_MAPP_CATEGORIES)
+public class CategoriesController {
+
+    @Autowired
+    private CategoriesService categoriesService;
+
+    @PostMapping
+    public ResponseEntity<CategoriesDTO> create(@Valid @RequestBody CategoriesDTO dto) {
+        CategoriesDTO result = categoriesService.save(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<CategoriesDTO> update(@PathVariable Long id, @Valid @RequestBody CategoriesDTO dto) {
+        CategoriesDTO result = categoriesService.update(id, dto);
+        return ResponseEntity.ok().body(result);
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/dto/CategoriesDTO.java
+++ b/src/main/java/com/alkemy/ong/dto/CategoriesDTO.java
@@ -4,11 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class CategoriesDTO {
 
+    @NotBlank(message = "The name must be a valid value.")
     private String name;
     private String description;
     private String image;

--- a/src/main/java/com/alkemy/ong/model/Categories.java
+++ b/src/main/java/com/alkemy/ong/model/Categories.java
@@ -33,8 +33,7 @@ public class Categories {
     private String image;
 
     @NotNull
-    @NotEmpty
-    private Boolean isActivated;
+    private Boolean isActivated = Boolean.TRUE ;
 
     @CreatedDate
     @Column (updatable = false)

--- a/src/main/java/com/alkemy/ong/security/WebSecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/security/WebSecurityConfig.java
@@ -42,8 +42,10 @@ protected void configure(HttpSecurity httpSecurity) throws Exception {
             .antMatchers(AUTH_ONLY_ADMINS).hasAuthority("ROLE_ADMIN") // Only Admins can access other locations in /auth/**
             .antMatchers(HttpMethod.GET, REQ_MAPP_ACTIVITIES).hasAnyAuthority(AUTHENTICATED_ROLES) // Only authenticated roles can access GET methods
             .antMatchers(HttpMethod.GET, REQ_MAPP_ORG).hasAnyAuthority(AUTHENTICATED_ROLES) // Idem above
+            .antMatchers(HttpMethod.GET, REQ_MAPP_ACTIVITIES).hasAnyAuthority(AUTHENTICATED_ROLES) // Idem above
             .antMatchers(REQ_MAPP_ACTIVITIES, REQ_MAPP_ACTIVITIES + "/**").hasAuthority("ROLE_ADMIN") // Only admins can access other methods
             .antMatchers(REQ_MAPP_ORG, REQ_MAPP_ORG + "/**").hasAuthority("ROLE_ADMIN") // Idem above
+            .antMatchers(REQ_MAPP_CATEGORIES, REQ_MAPP_CATEGORIES + "/**").hasAuthority("ROLE_ADMIN") // Idem above
             .antMatchers("/public/**").permitAll() // All users can access endpoints in /public/**
             .anyRequest().authenticated() // Only authenticated users can access the rest of endpoints
             .and()

--- a/src/main/java/com/alkemy/ong/service/CategoriesService.java
+++ b/src/main/java/com/alkemy/ong/service/CategoriesService.java
@@ -5,8 +5,11 @@ import com.alkemy.ong.dto.CategoriesDTO;
 
 public interface CategoriesService {
 
-    public CategoriesDTO publicDataCategory(String name);
+    CategoriesDTO publicDataCategory(String name);
 
-    public void deleteCategory(Long id);
+    void deleteCategory(Long id);
 
+    CategoriesDTO update(Long id, CategoriesDTO dto);
+
+    CategoriesDTO save(CategoriesDTO dto);
 }

--- a/src/main/java/com/alkemy/ong/service/CategoriesService.java
+++ b/src/main/java/com/alkemy/ong/service/CategoriesService.java
@@ -10,6 +10,4 @@ public interface CategoriesService {
     void deleteCategory(Long id);
 
     CategoriesDTO update(Long id, CategoriesDTO dto);
-
-    CategoriesDTO save(CategoriesDTO dto);
 }

--- a/src/main/java/com/alkemy/ong/service/CategoriesServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/CategoriesServiceImpl.java
@@ -50,13 +50,4 @@ public class CategoriesServiceImpl implements CategoriesService{
             throw new ParamNotFoundException("Requested category was not found.");
         }
     }
-
-    @Transactional
-    public CategoriesDTO save(CategoriesDTO dto) {
-        Categories entity = categoriesMapper.converToModel(dto);
-        Categories entitySaved = categoriesRepository.save(entity);
-
-        return categoriesMapper.converToDTO(entitySaved);
-    }
-
 }

--- a/src/main/java/com/alkemy/ong/service/CategoriesServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/CategoriesServiceImpl.java
@@ -1,12 +1,15 @@
 package com.alkemy.ong.service;
 
 import com.alkemy.ong.dto.CategoriesDTO;
+import com.alkemy.ong.exception.ParamNotFoundException;
 import com.alkemy.ong.mapper.CategoriesMapper;
 import com.alkemy.ong.model.Categories;
 import com.alkemy.ong.repository.CategoriesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Service
@@ -31,6 +34,29 @@ public class CategoriesServiceImpl implements CategoriesService{
         Categories category = answer.get();
         category.setIsActivated(false);
         categoriesRepository.save(category);
+    }
+
+    @Transactional
+    public CategoriesDTO update(Long id, CategoriesDTO dto) {
+
+        Optional<Categories> result = categoriesRepository.findById(id);
+        if (result.isPresent()) {
+            Categories entity = categoriesMapper.converToModel(dto);
+            entity.setId(id);
+            Categories entityUpdated = categoriesRepository.save(entity);
+
+            return categoriesMapper.converToDTO(entityUpdated);
+        } else {
+            throw new ParamNotFoundException("Requested category was not found.");
+        }
+    }
+
+    @Transactional
+    public CategoriesDTO save(CategoriesDTO dto) {
+        Categories entity = categoriesMapper.converToModel(dto);
+        Categories entitySaved = categoriesRepository.save(entity);
+
+        return categoriesMapper.converToDTO(entitySaved);
     }
 
 }

--- a/src/main/java/com/alkemy/ong/util/Constants.java
+++ b/src/main/java/com/alkemy/ong/util/Constants.java
@@ -4,6 +4,7 @@ public final class Constants {
 
     public static final String REQ_MAPP_ACTIVITIES = "/activities";
     public static final String REQ_MAPP_ORG = "/organizations";
+    public static final String REQ_MAPP_CATEGORIES = "/categories";
     public static final String POINT_GET_MAPP = "/public/{name}";
     public static final String ENTITY_NOT_FOUND = "ENTITY NOT FOUND";
     public static final String NAME_EXIST = "THE NAME OF THE ORGANIZATION ALREADY EXISTS";


### PR DESCRIPTION
Incidencia N° 43
COMO usuario administrador
QUIERO modificar una categoría existente
PARA mantener la información actualizada

Criterios de aceptación:
PUT /categories/:id - Deberá validar que la categoría existe y actualizarla, caso contrario devolver un error

### Modificaciones extras que debieron hacerse al código:
-  En Categories se removió la anotación @NotEmtpy del atributo boolean isActivated debido a conflictos con Hibernate (un booleano no debe tener esta anotación ya que es solo para Strings)
- En CategoriesDTO se añadió @NotBlank(message = "The name must be a valid value.") en el atributo String name para validar dicho atributo al querer actualizar
- En el método main, se añadió @EnableJpaAuditing para activar las anotaciones de auditoria como @CreatedDate y @LastModifiedDate
- En WebSecurityConfig, se añadió los métodos antMatchers para que solo ADMINS puedan acceder a este endpoint
