### PR TITLE
Fix: Query fix and Infinite loop fix in Slides

### DIFF
--- a/src/main/java/com/alkemy/ong/dto/SlidesResponseDTO.java
+++ b/src/main/java/com/alkemy/ong/dto/SlidesResponseDTO.java
@@ -1,7 +1,5 @@
 package com.alkemy.ong.dto;
 
-import com.alkemy.ong.model.Organizations;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,5 +15,5 @@ public class SlidesResponseDTO {
     private String imageUrl;
     private String text;
     private Integer order;
-    private Organizations organization;
+    private Long organizationId;
 }

--- a/src/main/java/com/alkemy/ong/mapper/SlidesMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/SlidesMapper.java
@@ -2,7 +2,6 @@ package com.alkemy.ong.mapper;
 
 import com.alkemy.ong.dto.SlidesDTO;
 import com.alkemy.ong.dto.SlidesResponseDTO;
-import com.alkemy.ong.dto.SlidesUpdateDto;
 import com.alkemy.ong.dto.SlidesUpdateResponseDTO;
 import com.alkemy.ong.model.Slides;
 import com.alkemy.ong.repository.OrganizationsRepository;
@@ -31,7 +30,7 @@ public class SlidesMapper {
                 .imageUrl(entity.getImageUrl())
                 .text(entity.getText())
                 .order(entity.getOrder())
-                .organization(organizationsRepository.getById(entity.getOrganization().getId()))
+                .organizationId(entity.getOrganization().getId())
                 .build();
     }
     

--- a/src/main/java/com/alkemy/ong/repository/SlidesRepository.java
+++ b/src/main/java/com/alkemy/ong/repository/SlidesRepository.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SlidesRepository extends JpaRepository<Slides, Long> {
    
-    @Query("SELECT c FROM Slide c WHERE organization_id = :idOrg")
+    @Query("SELECT c FROM Slides c WHERE organization_id = :idOrg")
     public Optional <List<Slides>> findByOrganizationId (@Param ("idOrg") Long id);
 	
 	public List<Slides> findByOrderByOrderAsc();

--- a/src/main/java/com/alkemy/ong/service/SlidesServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/SlidesServiceImpl.java
@@ -56,7 +56,7 @@ public class SlidesServiceImpl implements SlidesService {
         entity.setImageUrl(amazonS3Service.uploadFile(decodedImage).getFileUrl());
 
         Slides entityUpdated = slidesRepository.save(entity);
-        return slidesMapper.entity2ResponseDTO(entity);
+        return slidesMapper.entity2ResponseDTO(entityUpdated);
     }
 
     private MultipartFile decodeBase64Image2MultipartFile(String image64) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,12 +27,7 @@ spring.datasource.hikari.auto-commit= true
 springdoc.swagger-ui.path=/v3/api-docs/swagger-ui.html
 springdoc.swagger-ui.enabled=true
 
-#Amazon properties
-aws.s3.region= sa-east-1
-aws.s3.access_key= AKIA6FPUIQHWL5Y3PR7F
-aws.s3.secret_key= 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
-aws.s3.bucket_name= ong131
-aws.s3.endpoint_url = https://ong131.s3.sa-east-1.amazonaws.com/
+
 
 
 


### PR DESCRIPTION
Solicito el siguiente PR para aplicar 3 fixes a la rama develop:
-El 1er fix es al método findByOrganizationId de SlidesRepository que presenta un QueryCreationException
-El 2do es un fix al método POST de Crear Slide que genera en la respuesta a la petición un bucle infinito trayendo los Slides de Organization, el Organization del Slide... y así infinitamente
-El 3ero es eliminar la info de AWS que quedó colgada en el application.properties